### PR TITLE
Update hanger.scad for GOEWS stable compatibility and updated BOSL2

### DIFF
--- a/hanger.scad
+++ b/hanger.scad
@@ -107,7 +107,7 @@ module hanger_plate_unit(
                         }
                     }
                 }
-                if (bolt_notch)
+                if (bolt_notch && plate_thickness > bolt_notch_thickness)
                     translate([plate_width / 2, plate_cutout_y_offset + extend_bottom, bolt_notch_thickness])
                         cylinder(d=hanger_bolt_notch_head_clearance_diameter, h=plate_thickness - bolt_notch_thickness);
             }
@@ -142,7 +142,7 @@ module hanger_plate(
                         plate_thickness=plate_thickness,
                         hanger_tolerance=hanger_tolerance,
                         extend_bottom=extend_bottom,
-                        bolt_notch=bolt_notch,
+                        bolt_notch=bolt_notch
                     );
             }
         }


### PR DESCRIPTION
I was unable to open GOEWS in the stable version of OpenSCAD (2021.01) due to errors. This PR addresses those errors.

**Trailing comma**
A trailing comma in hanger.scad invalidated the syntax for OpenSCAD 2021.01. Any file importing this file would not be able to render.

**Invalid cylinder parameter**
**Symptom:** On BOSL2 v2.0.738 or newer, opening/rendering any part that uses the default back plate — e.g. shelf.scad, cup.scad — fails immediately with:

```
  ERROR: Assertion '(is_finite(h) && (h > 0))' failed: "
  h must be a positive number." in file .../BOSL2/shapes3d.scad, line 2019
  TRACE: called by 'cylinder' in file hanger.scad, line 112
```

**Root cause**: The latest BOSL2 overrides the built-in cylinder module. In commit [4e00fed4](https://github.com/BelfrySCAD/BOSL2/commit/4e00fed4) — "add parameter validation to cube(), cylinder(), sphere() modules", first released in v2.0.738 (2026-04) — it added assert(is_finite(h) && h > 0) to that override. Earlier BOSL2 (and OpenSCAD's built-in cylinder) treated a zero-height cylinder as a silent no-op.

In hanger.scad, the bolt-head clearance counterbore is:

```
  cylinder(d=hanger_bolt_notch_head_clearance_diameter, h=plate_thickness - bolt_notch_thickness);
```

Both plate_thickness and bolt_notch_thickness default to default_plate_thickness (3mm), so h = 0. Pre-validation BOSL2 produced empty geometry; v2.0.738+ now hard-asserts, so every part using the defaults fails to render.

**Fix:** only cut the counterbore when it has positive depth:

```
  if (bolt_notch && plate_thickness > bolt_notch_thickness)
```

---

This PR was Co-Authored with Claude Code