### PR TITLE
Implement tile stacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+*~
 **/__pycache__
 build
 frontend/.*

--- a/README.md
+++ b/README.md
@@ -35,6 +35,43 @@ have sharp edges.
 From testing, the original cleats, without bolts, held at 25lb and failed at 30lb. The
 thicker cleats held at 40lb and failed at 45lb.
 
+#### Tile stacks
+
+Tile stacks allow multiple tiles to be printed in a single job by alternating normal
+tile geometry with thin separator layers. The intended use is to print the tiles in
+PLA and the separators in PETG, taking advantage of the poor adhesion between those
+materials so the finished stack can be separated after printing.
+
+This requires a multi-material printer, toolchanger, or filament changer capable of
+printing PLA and PETG in the same job. Examples include toolchanger printers such as
+the [Snapmaker U1](https://www.snapmaker.com/en-CA/snapmaker-u1), multi-material
+systems such as the [Sovol M1D](https://www.sovol3d.com/pages/sovol-m1d-landing-page),
+or community filament changers such as the
+[Enraged Rabbit Project](https://github.com/EtteGit/EnragedRabbitProject) or [BoxTurtle Project](https://github.com/ArmoredTurtle/BoxTurtle)  for
+Voron/Klipper-style printers.
+
+In the web generator, tile stacks are available under **Tiles** as **Tile Stack**.
+The generator supports both hex and grid tiles, a configurable stack count, and the
+same tile sizing and mounting-hole options as the normal tile generators. The browser
+preview shows the tile bodies and separator layers as separate materials.
+
+When downloading a tile stack from the web generator, the download is a ZIP file
+containing two STL files:
+
+* `tile-stack-*.stl` — the tile bodies and any PLA support geometry
+* `tile-stack-*-spacers.stl` — the PETG separator layers and pull tabs
+
+Import both STLs into the slicer together as one multi-part object, keeping their
+relative positions unchanged. Assign the tile body STL to PLA and the spacer STL to
+PETG.
+
+In OrcaSlicer, enable multi-material printing, assign PLA and PETG to the two imported
+parts, then enable **Print Settings → Multimaterial → Advanced → Interface Shells**.
+This ensures solid layers are generated between the tile bodies and the separator
+layers. Do not enable interlocking beams for this use case; the goal is for the PLA and
+PETG layers to release from each other after printing, not to bond more strongly.
+
+
 ### Hooks
 
 Hooks are similar to the original ones. The shank and post dimensions are

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,7 +1,7 @@
 <script>
   import { Canvas } from '@threlte/core';
   import { onMount } from 'svelte';
-  import { getOpenAPISchema, extractParts, generateSTL, downloadSTL, getDefaultValues, generateFilename } from '$lib/api.js';
+  import { getOpenAPISchema, extractParts, generateSTL, downloadSTL, generateBlob, downloadBlob, getDefaultValues, generateFilename } from '$lib/api.js';
   import PartTreeSelector from './components/PartTreeSelector.svelte';
   import ParameterForm from './components/ParameterForm.svelte';
   import STLViewer from './components/STLViewer.svelte';
@@ -37,7 +37,7 @@
       if (partIds.length > 0) {
         // Default to tile if available, otherwise first part
         selectedPartId = parts['tile'] ? 'tile' : partIds[0];
-        
+
         // Try to load saved parameters for this part from localStorage
         const savedParams = localStorage.getItem(`params:${selectedPartId}`);
         if (savedParams) {
@@ -49,12 +49,12 @@
         } else {
           parameters = getDefaultValues(parts[selectedPartId].schema);
         }
-        
+
         // Apply global variant if the part has variant property
         if (parts[selectedPartId]?.schema?.properties?.variant !== undefined) {
           parameters.variant = globalVariant;
         }
-        
+
         initialized = true;
       }
     } catch (e) {
@@ -157,11 +157,42 @@
     }
   }
 
-  function download() {
-    if (!stlBlob || !currentPart) return;
-    const filename = generatedFilename || generateFilename(currentPart, parameters);
+  async function download() {
+    if (!currentPart) return;
+
+    const paramsToDownload = {
+      ...generatedParameters,
+    };
+
+    if (currentPart.schema?.properties?.variant !== undefined) {
+      paramsToDownload.variant = globalVariant;
+    }
+
+    if (currentPart.id === 'tile-stack') {
+      loading = true;
+      errorMessage = null;
+
+      try {
+        const { blob, filename } = await generateBlob('/api/tile-stack-bundle', {
+          ...paramsToDownload,
+          part: 'all',
+        });
+
+        downloadBlob(blob, filename || 'tile-stack.zip');
+      } catch (e) {
+        errorMessage = e.message;
+      } finally {
+        loading = false;
+      }
+
+      return;
+    }
+
+    if (!stlBlob) return;
+
+    const filename = generatedFilename || generateFilename(currentPart, generatedParameters);
     downloadSTL(stlBlob, filename);
-  }
+   }
 
   function resetParameters() {
     if (!currentPart) return;
@@ -273,7 +304,7 @@
       </div>
       {#if stlUrl && !isDirty}
         <button on:click={download} class="mt-4 bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
-          Download
+	  {currentPart?.id === 'tile-stack' ? 'Download ZIP' : 'Download'}
         </button>
       {/if}
     </div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
   import { Canvas } from '@threlte/core';
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { getOpenAPISchema, extractParts, generateSTL, downloadSTL, generateBlob, downloadBlob, getDefaultValues, generateFilename } from '$lib/api.js';
   import PartTreeSelector from './components/PartTreeSelector.svelte';
   import ParameterForm from './components/ParameterForm.svelte';
@@ -13,6 +13,7 @@
   let globalVariant = $state('Original');
   let stlUrl = $state(null);
   let stlBlob = $state(null);
+  let previewModels = $state([]);
   let loading = $state(false);
   let errorMessage = $state(null);
   let initialized = $state(false);
@@ -20,8 +21,11 @@
   let generatedParameters = $state({});
   let generatedFilename = $state(null);
 
+  let previewObjectUrls = new Set();
+
   let isDirty = $derived(initialized && JSON.stringify(parameters) !== JSON.stringify(generatedParameters));
   let currentPart = $derived(selectedPartId ? parts[selectedPartId] : null);
+  let previewKey = $derived(previewModels.map((previewModel) => previewModel.model).join('|'));
 
   onMount(async () => {
     // Load saved variant from localStorage
@@ -62,6 +66,10 @@
     }
   });
 
+  onDestroy(() => {
+    clearPreviewUrls();
+  });
+
   // Save variant to localStorage when it changes
   $effect(() => {
     if (initialized) {
@@ -74,6 +82,81 @@
     if (selectedPartId && Object.keys(parameters).length > 0) {
       localStorage.setItem(`params:${selectedPartId}`, JSON.stringify(parameters));
     }
+  }
+
+  function clearPreviewUrls() {
+    for (const url of previewObjectUrls) {
+      URL.revokeObjectURL(url);
+    }
+
+    previewObjectUrls = new Set();
+    stlUrl = null;
+    stlBlob = null;
+    previewModels = [];
+  }
+
+  function createPreviewUrl(blob) {
+    const url = URL.createObjectURL(blob);
+    previewObjectUrls.add(url);
+    return url;
+  }
+
+  async function generatePreview(partToGenerate, paramsToGenerate) {
+    clearPreviewUrls();
+
+    if (partToGenerate.id === 'tile-stack') {
+      const [pla, petg] = await Promise.all([
+        generateSTL(partToGenerate.endpoint, {
+          ...paramsToGenerate,
+          part: 'pla',
+        }),
+        generateSTL(partToGenerate.endpoint, {
+          ...paramsToGenerate,
+          part: 'petg',
+        }),
+      ]);
+
+      const plaUrl = createPreviewUrl(pla.blob);
+      const petgUrl = createPreviewUrl(petg.blob);
+
+      previewModels = [
+        {
+          model: plaUrl,
+          color: '#2f5f9e',
+          name: 'PLA tiles',
+        },
+        {
+          model: petgUrl,
+          color: '#f5b400',
+          name: 'PETG spacers',
+        },
+      ];
+
+      stlBlob = pla.blob;
+      stlUrl = plaUrl;
+
+      return {
+        filename: pla.filename,
+      };
+    }
+
+    const { blob, filename } = await generateSTL(partToGenerate.endpoint, paramsToGenerate);
+    const url = createPreviewUrl(blob);
+
+    previewModels = [
+      {
+        model: url,
+        color: '#2f5f9e',
+        name: partToGenerate.name,
+      },
+    ];
+
+    stlBlob = blob;
+    stlUrl = url;
+
+    return {
+      filename,
+    };
   }
 
   // Auto-generate when part selection changes
@@ -101,8 +184,6 @@
       }
     }
 
-    stlUrl = null;
-    stlBlob = null;
     generatedFilename = null;
     generatedParameters = {};
 
@@ -112,10 +193,8 @@
     loading = true;
     errorMessage = null;
 
-    generateSTL(partToGenerate.endpoint, newParams)
-      .then(({ blob, filename }) => {
-        stlBlob = blob;
-        stlUrl = URL.createObjectURL(blob);
+    generatePreview(partToGenerate, newParams)
+      .then(({ filename }) => {
         generatedFilename = filename;
         generatedParameters = { ...newParams };
         lastGeneratedPartId = selectedPartId;
@@ -143,9 +222,7 @@
     errorMessage = null;
 
     try {
-      const { blob, filename } = await generateSTL(partToGenerate.endpoint, paramsToGenerate);
-      stlBlob = blob;
-      stlUrl = URL.createObjectURL(blob);
+      const { filename } = await generatePreview(partToGenerate, paramsToGenerate);
       generatedFilename = filename;
       generatedParameters = { ...paramsToGenerate };
       lastGeneratedPartId = selectedPartId;
@@ -192,7 +269,7 @@
 
     const filename = generatedFilename || generateFilename(currentPart, generatedParameters);
     downloadSTL(stlBlob, filename);
-   }
+  }
 
   function resetParameters() {
     if (!currentPart) return;
@@ -289,9 +366,9 @@
     <!-- Viewer Panel -->
     <div class="lg:w-2/3 bg-white rounded-lg shadow p-4">
       <div class="h-[500px] bg-gray-50 rounded flex items-center justify-center">
-        {#if stlUrl}
-          <Canvas key={stlUrl}>
-            <STLViewer model={stlUrl} />
+        {#if previewModels.length > 0}
+          <Canvas key={previewKey}>
+            <STLViewer models={previewModels} />
           </Canvas>
         {:else if loading}
           <div class="text-gray-400 text-center">
@@ -303,8 +380,12 @@
         {/if}
       </div>
       {#if stlUrl && !isDirty}
-        <button on:click={download} class="mt-4 bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
-	  {currentPart?.id === 'tile-stack' ? 'Download ZIP' : 'Download'}
+        <button
+          on:click={download}
+          disabled={loading}
+          class="mt-4 bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50"
+        >
+          {currentPart?.id === 'tile-stack' ? 'Download ZIP' : 'Download'}
         </button>
       {/if}
     </div>

--- a/frontend/src/components/PartTreeSelector.svelte
+++ b/frontend/src/components/PartTreeSelector.svelte
@@ -9,7 +9,7 @@
     {
       id: 'tiles',
       name: 'Tiles',
-      parts: ['tile', 'grid-tile'],
+      parts: ['tile', 'grid-tile', 'tile-stack'],
     },
     {
       id: 'shelves',
@@ -26,6 +26,8 @@
   // Custom display names for parts
   const partDisplayNames = {
     tile: 'Standard Tile',
+    'grid-tile': 'Grid Tile',
+    'tile-stack': 'Tile Stack',
     shelf: 'Simple Shelf',
     mount: 'Hanger Mount',
     cableclip: 'Cable Clip',

--- a/frontend/src/components/STLViewer.svelte
+++ b/frontend/src/components/STLViewer.svelte
@@ -1,37 +1,70 @@
 <script>
   import { STLLoader } from 'three/examples/jsm/loaders/STLLoader';
+  import { Box3, Vector3, MeshStandardMaterial } from 'three';
   import { T } from '@threlte/core';
   import { OrbitControls, Resize, Align } from '@threlte/extras';
   import { writable } from 'svelte/store';
 
-  let { model } = $props();
-  const geometryStore = writable(null);
+  let { model = null, color = 'cornflowerblue', models = null } = $props();
+
+  const meshesStore = writable([]);
 
   $effect(() => {
-    if (!model) {
-      geometryStore.set(null);
+    const previewModels = models || (model ? [{ model, color }] : []);
+
+    if (previewModels.length === 0) {
+      meshesStore.set([]);
       return;
     }
 
     const loader = new STLLoader();
     let cancelled = false;
 
-    loader.load(
-      model,
-      (loadedGeometry) => {
-        if (!cancelled) {
-          loadedGeometry.center();
-          geometryStore.set(loadedGeometry);
+    async function loadModel(previewModel) {
+      return await new Promise((resolve, reject) => {
+        loader.load(
+          previewModel.model,
+          (geometry) => {
+            resolve({
+              geometry,
+              material: new MeshStandardMaterial({
+                color: previewModel.color || 'cornflowerblue',
+              }),
+            });
+          },
+          undefined,
+          reject
+        );
+      });
+    }
+
+    Promise.all(previewModels.map(loadModel))
+      .then((loadedMeshes) => {
+        if (cancelled) return;
+
+        const bounds = new Box3();
+
+        for (const mesh of loadedMeshes) {
+          mesh.geometry.computeBoundingBox();
+          bounds.union(mesh.geometry.boundingBox);
         }
-      },
-      undefined,
-      (error) => {
+
+        const center = new Vector3();
+        bounds.getCenter(center);
+
+        for (const mesh of loadedMeshes) {
+          mesh.geometry.translate(-center.x, -center.y, -center.z);
+          mesh.geometry.computeVertexNormals();
+        }
+
+        meshesStore.set(loadedMeshes);
+      })
+      .catch((error) => {
         if (!cancelled) {
           console.error('Failed to load STL:', error);
-          geometryStore.set(null);
+          meshesStore.set([]);
         }
-      }
-    );
+      });
 
     return () => {
       cancelled = true;
@@ -46,13 +79,13 @@
 <T.AmbientLight intensity={0.25} />
 <T.DirectionalLight position={[1, 1, 1]} intensity={1} />
 
-{#if $geometryStore}
+{#if $meshesStore.length > 0}
   <T.Group scale={7}>
     <Resize>
       <Align auto>
-        <T.Mesh geometry={$geometryStore}>
-          <T.MeshStandardMaterial color="cornflowerblue" />
-        </T.Mesh>
+        {#each $meshesStore as mesh}
+          <T.Mesh geometry={mesh.geometry} material={mesh.material} />
+        {/each}
       </Align>
     </Resize>
   </T.Group>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -88,6 +88,56 @@ export function extractParts(openapi) {
 }
 
 /**
+ * Generate blob from endpoint
+ * @param {string} endpoint - API endpoint
+ * @param {Object} parameters - Parameters object
+ * @returns {Promise<{blob: Blob, filename: string}>}
+ */
+export async function generateBlob(endpoint, parameters) {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(parameters),
+  });
+
+  if (!response.ok) {
+    const error = await response.text().catch(() => 'Model generation failed');
+    throw new Error(error || 'Model generation failed');
+  }
+
+  const contentDisposition = response.headers.get('Content-Disposition');
+  let filename = null;
+
+  const filenameMatch = contentDisposition?.match(/filename="?([^"]+)"?/);
+  if (filenameMatch) {
+    filename = filenameMatch[1].trim();
+  }
+
+  return {
+    blob: await response.blob(),
+    filename,
+  };
+}
+
+/**
+ * Download arbitrary blob as file
+ * @param {Blob} blob - Blob to download
+ * @param {string} filename - Filename for download
+ */
+export function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
  * Generate STL from endpoint
  * @param {string} endpoint - API endpoint
  * @param {Object} parameters - Parameters object

--- a/server/parts/tile_stack.py
+++ b/server/parts/tile_stack.py
@@ -1,0 +1,128 @@
+from enum import StrEnum
+from typing import Annotated
+
+from pydantic import BaseModel, Field, field_validator
+from sanic import response
+from sanic.request import Request
+from sanic_ext import openapi, validate
+from server.api import api_bp
+from server.enums import Variant
+from server.openscad import build
+
+
+@openapi.component
+class TileKind(StrEnum):
+    HEX = "hex"
+    GRID = "grid"
+
+
+@openapi.component
+class StackPart(StrEnum):
+    PLA = "pla"
+    PETG = "petg"
+    ALL = "all"
+
+
+@openapi.component
+class TileStackDefinition(BaseModel):
+    tile_kind: TileKind = TileKind.HEX
+    part: StackPart = StackPart.PLA
+
+    stack_count: Annotated[
+        int, Field(gt=1, description="Number of tiles in the stack")
+    ] = 3
+    spacer_h: Annotated[
+        float, Field(gt=0, description="PETG separator thickness in mm")
+    ] = 0.2
+    spacer_xy_delta: Annotated[
+        float, Field(description="XY shrink/expand for separator")
+    ] = -0.2
+
+    enable_pull_tabs: bool = True
+    tab_side: Annotated[str, Field(description="right, left, front, or back")] = "right"
+    tab_len: Annotated[float, Field(gt=0)] = 22
+    tab_support_tile_gap: Annotated[float, Field(ge=0)] = 1.5
+
+    columns: Annotated[int, Field(gt=0, description="Tile columns in units")] = 4
+    rows: Annotated[int, Field(gt=0, description="Tile rows in units")] = 4
+
+    fill_top: bool = False
+    fill_bottom: bool = False
+    fill_left: bool = False
+    fill_right: bool = False
+    reverse_stagger: bool = False
+    exact_width: bool = False
+
+    mounting_hole_shank_diameter: Annotated[float, Field(gt=0)] = 4
+    mounting_hole_head_diameter: Annotated[float, Field(gt=0)] = 8
+    mounting_hole_inset_depth: Annotated[float, Field(gt=0)] = 1
+    mounting_hole_countersink_depth: Annotated[float, Field(ge=0)] = 2
+
+    skip_list: Annotated[list[list[int]], Field(description="Tiles to exclude")] = []
+
+    variant: Variant = Variant.ORIGINAL
+
+    @field_validator("skip_list", mode="after")
+    @classmethod
+    def validate_skip_list(cls, value):
+        for coordinate in value:
+            if len(coordinate) != 2:
+                raise ValueError("Skip list must be a list of [row, column] pairs")
+            if coordinate[0] <= 0 or coordinate[1] <= 0:
+                raise ValueError(
+                    "Skip list rows and columns must be greater than zero."
+                )
+        return value
+
+
+def make_tile_stack_filename(body: TileStackDefinition) -> str:
+    variant = "original" if body.variant.to_int() == 0 else "thicker_cleats"
+    return (
+        f"tile-stack-{body.tile_kind}-{body.part}-"
+        f"{body.columns}x{body.rows}-"
+        f"{body.stack_count}high-{variant}.stl"
+    )
+
+
+@api_bp.post("/tile-stack")
+@openapi.body(TileStackDefinition)
+@openapi.response(200, "model/stl")
+@openapi.summary("Tile Stack")
+@openapi.description("Create a stacked GOEWS tile assembly for PLA/PETG printing")
+@validate(json=TileStackDefinition)
+async def tile_stack(request: Request, body: TileStackDefinition):
+    skip_list = ",".join(repr(entry) for entry in body.skip_list)
+    filename = make_tile_stack_filename(body)
+
+    return response.raw(
+        await build(
+            "tile_stack.scad",
+            tile_kind=body.tile_kind.value,
+            part=body.part.value,
+            stack_count=body.stack_count,
+            spacer_h=body.spacer_h,
+            spacer_xy_delta=body.spacer_xy_delta,
+            enable_pull_tabs=body.enable_pull_tabs,
+            tab_side=body.tab_side,
+            tab_len=body.tab_len,
+            tab_support_tile_gap=body.tab_support_tile_gap,
+            variant=body.variant.to_int(),
+            columns=body.columns,
+            rows=body.rows,
+            fill_top=body.fill_top,
+            fill_bottom=body.fill_bottom,
+            fill_left=body.fill_left,
+            fill_right=body.fill_right,
+            reverse_stagger=body.reverse_stagger,
+            exact_width=body.exact_width,
+            mounting_hole_shank_diameter=body.mounting_hole_shank_diameter,
+            mounting_hole_head_diameter=body.mounting_hole_head_diameter,
+            mounting_hole_inset_depth=body.mounting_hole_inset_depth,
+            mounting_hole_countersink_depth=body.mounting_hole_countersink_depth,
+            # Match the existing GOEWS convention:
+            # tile.scad exposes skip_list as a string and parses it.
+            skip_list=skip_list,
+        ),
+        content_type="model/stl",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/server/parts/tile_stack.py
+++ b/server/parts/tile_stack.py
@@ -1,3 +1,6 @@
+import asyncio
+import io
+import zipfile
 from enum import StrEnum
 from typing import Annotated
 
@@ -84,6 +87,45 @@ def make_tile_stack_filename(body: TileStackDefinition) -> str:
     )
 
 
+def tile_stack_build_params(body: TileStackDefinition, part: StackPart) -> dict:
+    skip_list = ",".join(repr(entry) for entry in body.skip_list)
+
+    return {
+        "tile_kind": body.tile_kind.value,
+        "part": part.value,
+        "stack_count": body.stack_count,
+        "spacer_h": body.spacer_h,
+        "spacer_xy_delta": body.spacer_xy_delta,
+        "enable_pull_tabs": body.enable_pull_tabs,
+        "tab_side": body.tab_side,
+        "tab_len": body.tab_len,
+        "tab_support_tile_gap": body.tab_support_tile_gap,
+        "variant": body.variant.to_int(),
+        "columns": body.columns,
+        "rows": body.rows,
+        "fill_top": body.fill_top,
+        "fill_bottom": body.fill_bottom,
+        "fill_left": body.fill_left,
+        "fill_right": body.fill_right,
+        "reverse_stagger": body.reverse_stagger,
+        "exact_width": body.exact_width,
+        "mounting_hole_shank_diameter": body.mounting_hole_shank_diameter,
+        "mounting_hole_head_diameter": body.mounting_hole_head_diameter,
+        "mounting_hole_inset_depth": body.mounting_hole_inset_depth,
+        "mounting_hole_countersink_depth": body.mounting_hole_countersink_depth,
+        "skip_list": skip_list,
+    }
+
+
+def make_tile_stack_basename(body: TileStackDefinition) -> str:
+    variant = "original" if body.variant.to_int() == 0 else "thicker-cleats"
+    return (
+        f"tile-stack-{body.tile_kind.value}-"
+        f"{body.columns}x{body.rows}-"
+        f"{body.stack_count}high-{variant}"
+    )
+
+
 @api_bp.post("/tile-stack")
 @openapi.body(TileStackDefinition)
 @openapi.response(200, "model/stl")
@@ -91,38 +133,49 @@ def make_tile_stack_filename(body: TileStackDefinition) -> str:
 @openapi.description("Create a stacked GOEWS tile assembly for PLA/PETG printing")
 @validate(json=TileStackDefinition)
 async def tile_stack(request: Request, body: TileStackDefinition):
-    skip_list = ",".join(repr(entry) for entry in body.skip_list)
     filename = make_tile_stack_filename(body)
 
     return response.raw(
         await build(
             "tile_stack.scad",
-            tile_kind=body.tile_kind.value,
-            part=body.part.value,
-            stack_count=body.stack_count,
-            spacer_h=body.spacer_h,
-            spacer_xy_delta=body.spacer_xy_delta,
-            enable_pull_tabs=body.enable_pull_tabs,
-            tab_side=body.tab_side,
-            tab_len=body.tab_len,
-            tab_support_tile_gap=body.tab_support_tile_gap,
-            variant=body.variant.to_int(),
-            columns=body.columns,
-            rows=body.rows,
-            fill_top=body.fill_top,
-            fill_bottom=body.fill_bottom,
-            fill_left=body.fill_left,
-            fill_right=body.fill_right,
-            reverse_stagger=body.reverse_stagger,
-            exact_width=body.exact_width,
-            mounting_hole_shank_diameter=body.mounting_hole_shank_diameter,
-            mounting_hole_head_diameter=body.mounting_hole_head_diameter,
-            mounting_hole_inset_depth=body.mounting_hole_inset_depth,
-            mounting_hole_countersink_depth=body.mounting_hole_countersink_depth,
-            # Match the existing GOEWS convention:
-            # tile.scad exposes skip_list as a string and parses it.
-            skip_list=skip_list,
+            **tile_stack_build_params(body, body.part),
         ),
         content_type="model/stl",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@api_bp.post("/tile-stack-bundle")
+@openapi.body(TileStackDefinition)
+@openapi.response(200, "application/zip")
+@openapi.summary("Tile Stack Bundle")
+@openapi.description(
+    "Create PLA tile and PETG spacer STLs for a stacked GOEWS tile assembly"
+)
+@validate(json=TileStackDefinition)
+async def tile_stack_bundle(request: Request, body: TileStackDefinition):
+    basename = make_tile_stack_basename(body)
+
+    pla_task = build(
+        "tile_stack.scad",
+        **tile_stack_build_params(body, StackPart.PLA),
+    )
+    petg_task = build(
+        "tile_stack.scad",
+        **tile_stack_build_params(body, StackPart.PETG),
+    )
+
+    pla_stl, petg_stl = await asyncio.gather(pla_task, petg_task)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(f"{basename}.stl", pla_stl)
+        zf.writestr(f"{basename}-spacers.stl", petg_stl)
+
+    return response.raw(
+        buf.getvalue(),
+        content_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{basename}.zip"',
+        },
     )

--- a/server/server.py
+++ b/server/server.py
@@ -3,11 +3,11 @@ Web-based GOEWS model generator
 """
 
 from pathlib import Path
+
 from sanic import Sanic, response
 from sanic_ext import Extend, openapi
 
 from server.api import api_bp
-
 
 top_dir = (Path(__file__) / "../..").resolve()
 frontend_dir = top_dir / "frontend/dist"
@@ -43,9 +43,10 @@ import server.parts.gridfinity_bin
 import server.parts.gridfinity_shelf
 import server.parts.hook
 import server.parts.mount
-import server.parts.tile
 import server.parts.rack
 import server.parts.shelf
+import server.parts.tile
+import server.parts.tile_stack
 
 # Register the blueprint after routes are added
 app.blueprint(api_bp)

--- a/stacked_goews_tiles.scad
+++ b/stacked_goews_tiles.scad
@@ -1,55 +1,122 @@
 // stacked_goews_tiles.scad
 //
 // Export twice:
+//
 //   openscad -o goews-stack-pla.stl  -D 'part="pla"'  stacked_goews_tiles.scad
 //   openscad -o goews-stack-petg.stl -D 'part="petg"' stacked_goews_tiles.scad
 //
 // Then import both STLs into Orca as one multi-part object.
 // Assign PLA to goews-stack-pla.stl and PETG to goews-stack-petg.stl.
+//
+// In Orca:
+//   - Enable multimaterial / multiple filaments
+//   - Assign PLA to tiles + supports
+//   - Assign PETG to separators + tabs
+//   - Enable "Interface Shells"
+//   - Do not use interlocking beams for this
 
 include <constants.scad>
+include <BOSL2/std.scad>
+include <BOSL2/lists.scad>
+include <BOSL2/threading.scad>
 
-// Use, do not include, because tile.scad/grid_tile.scad each render
-// a top-level object at the bottom of the file.
 use <tile.scad>
 use <grid_tile.scad>
 
 /* [Stack] */
 
-// "hex" or "grid"
+// "hex" or "grid". Hex is the primary path here.
 tile_kind = "hex";
 
 // "pla", "petg", or "all" for preview
-part = "petg";
+part = "all";
 
 // Number of actual GOEWS tiles in the stack
 stack_count = 3;
 
 // PETG separator thickness.
-// Start with one or two layer heights. For 0.2mm layers, try 0.2 or 0.4.
-spacer_h = 0.4;
+// Try 0.2 for one layer, 0.4 for two layers.
+spacer_h = 0.2;
 
-// Slight XY adjustment for spacer sheets.
-// 0 = exact first-layer footprint.
-// -0.05 or -0.10 can reduce PETG fins around the outside.
-spacer_xy_delta = -0.05;
+// Shrink the separator slightly so it does not poke past the plate edge/chamfer.
+spacer_xy_delta = -0.20;
 
-/* [GOEWS tile parameters] */
+// "hex_cells" is fast and recommended for hex GOEWS plates.
+// "projection_close" is slower, but useful if you use GOEWS fill_top/fill_bottom/etc.
+separator_mode = "hex_cells";
+
+// Used only by separator_mode="projection_close".
+// Should be bigger than the largest hole radius you want closed.
+separator_close_radius = 9;
+
+// Tiny visual/alignment nudge, in case your local GOEWS checkout differs.
+separator_nudge_x = 0;
+separator_nudge_y = 0;
+
+/* [Pull Tabs] */
+
+enable_pull_tabs = true;
+
+// "right", "left", "front", or "back"
+// Right is the safest default for normal hex plates because the default stagger
+// usually gives you a good mid-row attachment on that side.
+tab_side = "right";
+
+// How far the PETG tab sticks out beyond the plate footprint.
+tab_len = 22;
+
+// Width of the PETG tab.
+tab_width = 18;
+
+// How much the PETG tab overlaps into the separator sheet.
+tab_overlap = 4;
+
+// Rounded tab corners.
+tab_radius = 3;
+
+/* [PLA Tab Supports] */
+
+// Add modeled PLA support islands under the exposed PETG pull tabs.
+// These are actual PLA geometry, not slicer-generated supports.
+enable_tab_supports = true;
+
+// Keep support island separated from the tile by this much.
+tab_support_tile_gap = 1.5;
+
+// Leave this much of the outer PETG tab unsupported/free for easier grabbing.
+tab_tip_free = 5;
+
+// Width of PLA support under tab.
+// Slightly narrower than tab_width makes it easier to break away.
+tab_support_width = 14;
+
+// Slightly round the support island corners.
+tab_support_radius = 2;
+
+// Height gap below PETG separator.
+// 0 gives the best tab print reliability.
+// Try 0.05 only if PETG bonds too hard to the PLA support.
+tab_support_z_gap = 0;
+
+/* [GOEWS Tile Parameters] */
 
 variant = 1; // 0 original, 1 thicker cleats
 
 columns = 4;
 rows = 4;
 
-// Hex-only edge fill params
+// Hex edge fill params.
+// The fast hex_cells separator does not model these fill pieces.
+// Use separator_mode="projection_close" when these are enabled.
 fill_top = false;
 fill_bottom = false;
 fill_left = false;
 fill_right = false;
+
 reverse_stagger = false;
 exact_width = false;
 
-// Use real vector form here, not the GOEWS customizer string.
+// GOEWS skiplist uses 1-based [row, column] entries.
 // Example: [[1, 2], [3, 4]]
 skiplist = [];
 
@@ -64,6 +131,63 @@ $fa = 0.5;
 $fs = 0.5;
 
 stack_pitch = tile_thickness + spacer_h;
+
+// Match tile.scad's stagger logic.
+function hex_stagger_0() = reverse_stagger ? 1 : 0;
+function hex_stagger_1() = reverse_stagger ? 0 : 1;
+
+function hex_row_offset_x(row) =
+  (row % 2 == hex_stagger_0()) ? tile_width / 2 : 0;
+
+function hex_row_start_column(row) =
+  exact_width && (row % 2 == hex_stagger_1()) ? 1 : 0;
+
+function hex_row_min_x(row) =
+  hex_row_offset_x(row) + hex_row_start_column(row) * tile_width;
+
+function hex_row_max_x(row) =
+  hex_row_offset_x(row) + columns * tile_width;
+
+hex_min_x = min([for (row = [0 : rows - 1]) hex_row_min_x(row)]);
+hex_max_x = max([for (row = [0 : rows - 1]) hex_row_max_x(row)]);
+hex_min_y = 0;
+hex_max_y = (rows - 1) * tile_y_offset + tile_height;
+
+grid_min_x = 0;
+grid_max_x = columns * tile_width;
+grid_min_y = 0;
+grid_max_y = rows * grid_tile_height;
+
+footprint_min_x = tile_kind == "grid" ? grid_min_x : hex_min_x;
+footprint_max_x = tile_kind == "grid" ? grid_max_x : hex_max_x;
+footprint_min_y = tile_kind == "grid" ? grid_min_y : hex_min_y;
+footprint_max_y = tile_kind == "grid" ? grid_max_y : hex_max_y;
+
+footprint_center_x = (footprint_min_x + footprint_max_x) / 2;
+footprint_center_y = (footprint_min_y + footprint_max_y) / 2;
+
+module rounded_rect_2d(size=[10, 5], r=2) {
+  rr = min(r, min(size[0], size[1]) / 2 - 0.01);
+
+  offset(r=rr)
+    square([
+      max(0.01, size[0] - 2 * rr),
+      max(0.01, size[1] - 2 * rr)
+    ], center=true);
+}
+
+// Solid 2D version of GOEWS' pointy hex tile outline.
+// This deliberately omits hanger holes, screw holes, rear cuts, etc.
+module solid_hex_cell_2d() {
+  polygon(points=[
+    [tile_width / 2, 0],
+    [tile_width, tile_height / 4],
+    [tile_width, 3 * tile_height / 4],
+    [tile_width / 2, tile_height],
+    [0, 3 * tile_height / 4],
+    [0, tile_height / 4]
+  ]);
+}
 
 module one_tile() {
   if (tile_kind == "grid") {
@@ -99,13 +223,132 @@ module one_tile() {
   }
 }
 
-// The spacer is the first-layer footprint of the next tile.
-// That is usually what you want the upper tile to start on.
-module spacer_sheet() {
-  linear_extrude(height=spacer_h)
+module hex_cells_separator_2d() {
+  translate([separator_nudge_x, separator_nudge_y])
     offset(delta=spacer_xy_delta)
-      projection(cut=true)
-        one_tile();
+      union() {
+        for (row = [0 : rows - 1]) {
+          offset_x = hex_row_offset_x(row);
+          start_column = hex_row_start_column(row);
+          pos_y = row * tile_y_offset;
+
+          for (column = [start_column : columns - 1]) {
+            pos_x = offset_x + column * tile_width;
+
+            if (!in_list([row + 1, column + 1], skiplist)) {
+              translate([pos_x, pos_y])
+                solid_hex_cell_2d();
+            }
+          }
+        }
+      }
+}
+
+// Slower fallback that preserves the projected outside outline much better than hull().
+// This can handle fill_top/fill_bottom/fill_left/fill_right more faithfully,
+// but it is much slower because it projects the real tile.
+module projection_closed_separator_2d() {
+  translate([separator_nudge_x, separator_nudge_y])
+    offset(delta=spacer_xy_delta)
+      offset(delta=-separator_close_radius)
+        offset(delta=separator_close_radius)
+          projection(cut=true)
+            one_tile();
+}
+
+module grid_separator_2d() {
+  translate([separator_nudge_x, separator_nudge_y])
+    offset(delta=spacer_xy_delta)
+      square([grid_max_x - grid_min_x, grid_max_y - grid_min_y], center=false);
+}
+
+module separator_footprint_2d() {
+  if (tile_kind == "grid") {
+    grid_separator_2d();
+  } else if (separator_mode == "projection_close") {
+    projection_closed_separator_2d();
+  } else {
+    hex_cells_separator_2d();
+  }
+}
+
+module tab_2d() {
+  if (tab_side == "right") {
+    translate([
+      footprint_max_x + (tab_len - tab_overlap) / 2,
+      footprint_center_y
+    ])
+      rounded_rect_2d([tab_len + tab_overlap, tab_width], tab_radius);
+
+  } else if (tab_side == "left") {
+    translate([
+      footprint_min_x - (tab_len - tab_overlap) / 2,
+      footprint_center_y
+    ])
+      rounded_rect_2d([tab_len + tab_overlap, tab_width], tab_radius);
+
+  } else if (tab_side == "back") {
+    translate([
+      footprint_center_x,
+      footprint_max_y + (tab_len - tab_overlap) / 2
+    ])
+      rounded_rect_2d([tab_width, tab_len + tab_overlap], tab_radius);
+
+  } else {
+    // "front"
+    translate([
+      footprint_center_x,
+      footprint_min_y - (tab_len - tab_overlap) / 2
+    ])
+      rounded_rect_2d([tab_width, tab_len + tab_overlap], tab_radius);
+  }
+}
+
+// Support is intentionally separated from the tile footprint.
+// It starts outside the plate edge plus tab_support_tile_gap,
+// and stops before the tab tip by tab_tip_free.
+module tab_support_2d() {
+  support_len = max(0.01, tab_len - tab_tip_free - tab_support_tile_gap);
+
+  if (tab_side == "right") {
+    translate([
+      footprint_max_x + tab_support_tile_gap + support_len / 2,
+      footprint_center_y
+    ])
+      rounded_rect_2d([support_len, tab_support_width], tab_support_radius);
+
+  } else if (tab_side == "left") {
+    translate([
+      footprint_min_x - tab_support_tile_gap - support_len / 2,
+      footprint_center_y
+    ])
+      rounded_rect_2d([support_len, tab_support_width], tab_support_radius);
+
+  } else if (tab_side == "back") {
+    translate([
+      footprint_center_x,
+      footprint_max_y + tab_support_tile_gap + support_len / 2
+    ])
+      rounded_rect_2d([tab_support_width, support_len], tab_support_radius);
+
+  } else {
+    // "front"
+    translate([
+      footprint_center_x,
+      footprint_min_y - tab_support_tile_gap - support_len / 2
+    ])
+      rounded_rect_2d([tab_support_width, support_len], tab_support_radius);
+  }
+}
+
+module separator_sheet() {
+  linear_extrude(height=spacer_h)
+    union() {
+      separator_footprint_2d();
+
+      if (enable_pull_tabs)
+        tab_2d();
+    }
 }
 
 module pla_tiles() {
@@ -115,18 +358,35 @@ module pla_tiles() {
   }
 }
 
-module petg_spacers() {
+module pla_tab_supports() {
+  support_h = max(0.01, tile_thickness - tab_support_z_gap);
+
+  for (i = [0 : stack_count - 2]) {
+    translate([0, 0, i * stack_pitch])
+      linear_extrude(height=support_h)
+        tab_support_2d();
+  }
+}
+
+module pla_part() {
+  pla_tiles();
+
+  if (enable_pull_tabs && enable_tab_supports)
+    pla_tab_supports();
+}
+
+module petg_part() {
   for (i = [0 : stack_count - 2]) {
     translate([0, 0, i * stack_pitch + tile_thickness])
-      spacer_sheet();
+      separator_sheet();
   }
 }
 
 if (part == "pla") {
-  pla_tiles();
+  pla_part();
 } else if (part == "petg") {
-  petg_spacers();
+  petg_part();
 } else {
-  color("lightgray") pla_tiles();
-  color("orange") petg_spacers();
+  color("lightgray") pla_part();
+  color("orange") petg_part();
 }

--- a/stacked_goews_tiles.scad
+++ b/stacked_goews_tiles.scad
@@ -1,0 +1,132 @@
+// stacked_goews_tiles.scad
+//
+// Export twice:
+//   openscad -o goews-stack-pla.stl  -D 'part="pla"'  stacked_goews_tiles.scad
+//   openscad -o goews-stack-petg.stl -D 'part="petg"' stacked_goews_tiles.scad
+//
+// Then import both STLs into Orca as one multi-part object.
+// Assign PLA to goews-stack-pla.stl and PETG to goews-stack-petg.stl.
+
+include <constants.scad>
+
+// Use, do not include, because tile.scad/grid_tile.scad each render
+// a top-level object at the bottom of the file.
+use <tile.scad>
+use <grid_tile.scad>
+
+/* [Stack] */
+
+// "hex" or "grid"
+tile_kind = "hex";
+
+// "pla", "petg", or "all" for preview
+part = "petg";
+
+// Number of actual GOEWS tiles in the stack
+stack_count = 3;
+
+// PETG separator thickness.
+// Start with one or two layer heights. For 0.2mm layers, try 0.2 or 0.4.
+spacer_h = 0.4;
+
+// Slight XY adjustment for spacer sheets.
+// 0 = exact first-layer footprint.
+// -0.05 or -0.10 can reduce PETG fins around the outside.
+spacer_xy_delta = -0.05;
+
+/* [GOEWS tile parameters] */
+
+variant = 1; // 0 original, 1 thicker cleats
+
+columns = 4;
+rows = 4;
+
+// Hex-only edge fill params
+fill_top = false;
+fill_bottom = false;
+fill_left = false;
+fill_right = false;
+reverse_stagger = false;
+exact_width = false;
+
+// Use real vector form here, not the GOEWS customizer string.
+// Example: [[1, 2], [3, 4]]
+skiplist = [];
+
+mounting_hole_shank_diameter = 4;
+mounting_hole_head_diameter = 8;
+mounting_hole_inset_depth = 1;
+mounting_hole_countersink_depth = 2;
+
+/* [Hidden] */
+
+$fa = 0.5;
+$fs = 0.5;
+
+stack_pitch = tile_thickness + spacer_h;
+
+module one_tile() {
+  if (tile_kind == "grid") {
+    grid_tile(
+      variant=variant,
+      columns=columns,
+      rows=rows,
+      mounting_hole_shank_diameter=mounting_hole_shank_diameter,
+      mounting_hole_head_diameter=mounting_hole_head_diameter,
+      mounting_hole_inset_depth=mounting_hole_inset_depth,
+      mounting_hole_countersink_depth=mounting_hole_countersink_depth,
+      skiplist=skiplist
+    );
+  } else {
+    tile(
+      variant=variant,
+      columns=columns,
+      rows=rows,
+      fill_top=fill_top,
+      fill_bottom=fill_bottom,
+      fill_left=fill_left,
+      fill_right=fill_right,
+      reverse_stagger=reverse_stagger,
+      exact_width=exact_width,
+      mounting_hole_shank_diameter=mounting_hole_shank_diameter,
+      mounting_hole_head_diameter=mounting_hole_head_diameter,
+      mounting_hole_inset_depth=mounting_hole_inset_depth,
+      mounting_hole_countersink_depth=mounting_hole_countersink_depth,
+      skiplist=skiplist,
+      cut_outside_corners=true,
+      chamfer_rear=true
+    );
+  }
+}
+
+// The spacer is the first-layer footprint of the next tile.
+// That is usually what you want the upper tile to start on.
+module spacer_sheet() {
+  linear_extrude(height=spacer_h)
+    offset(delta=spacer_xy_delta)
+      projection(cut=true)
+        one_tile();
+}
+
+module pla_tiles() {
+  for (i = [0 : stack_count - 1]) {
+    translate([0, 0, i * stack_pitch])
+      one_tile();
+  }
+}
+
+module petg_spacers() {
+  for (i = [0 : stack_count - 2]) {
+    translate([0, 0, i * stack_pitch + tile_thickness])
+      spacer_sheet();
+  }
+}
+
+if (part == "pla") {
+  pla_tiles();
+} else if (part == "petg") {
+  petg_spacers();
+} else {
+  color("lightgray") pla_tiles();
+  color("orange") petg_spacers();
+}

--- a/tile.scad
+++ b/tile.scad
@@ -54,6 +54,10 @@ skip_list = "";
 $fa=0.5;
 $fs=0.5;
 
+// Small boolean overcut to avoid coplanar faces / zero-thickness STL scraps.
+// These can show up in the browser preview as "filled" hanger windows even
+// though slicers usually discard them.
+bool_eps = 0.02;
 
 module tile_cleat(variant=variant_original) {
     difference() {
@@ -91,13 +95,24 @@ module mounting_hole(
     mounting_hole_inset_depth=1,
     mounting_hole_countersink_depth=2,
 ) {
-        cylinder(h=tile_thickness, d=mounting_hole_shank_diameter);
-        translate([0, 0, tile_thickness - mounting_hole_inset_depth])
-            cylinder(h=mounting_hole_inset_depth, d=mounting_hole_head_diameter);
-        if (mounting_hole_countersink_depth > 0) {
-            translate([0, 0, tile_thickness - mounting_hole_inset_depth])
-                zcyl(h=mounting_hole_countersink_depth, d1=mounting_hole_shank_diameter, d2=mounting_hole_head_diameter, anchor=TOP);
-        }
+    // Overcut each cutter slightly so the mounting hole does not leave
+    // coplanar scraps in the preview/STL. The overlaps are internal to the
+    // subtracted shape and do not meaningfully change the printed dimensions.
+    translate([0, 0, -bool_eps])
+        cylinder(h=tile_thickness + 2 * bool_eps, d=mounting_hole_shank_diameter);
+
+    translate([0, 0, tile_thickness - mounting_hole_inset_depth - bool_eps])
+        cylinder(h=mounting_hole_inset_depth + 2 * bool_eps, d=mounting_hole_head_diameter);
+
+    if (mounting_hole_countersink_depth > 0) {
+        translate([0, 0, tile_thickness - mounting_hole_inset_depth + bool_eps])
+            zcyl(
+                h=mounting_hole_countersink_depth + 2 * bool_eps,
+                d1=mounting_hole_shank_diameter,
+                d2=mounting_hole_head_diameter,
+                anchor=TOP
+            );
+    }
 }
 
 
@@ -184,14 +199,16 @@ module hex_tile_single(
                 }
             }
 
-        // Space for hanger
-        linear_extrude(height=tile_thickness)
-            difference() {
-                translate([hanger_x_offset, tile_hanger_y_offset, 0])
-                    square([tile_hanger_width, tile_hanger_height]);
-                translate([threaded_hole_center_x, threaded_hole_center_y, 0])
-                    circle(tile_hanger_hole_outer_diameter);
-            }
+	// Space for hanger
+	translate([0, 0, -bool_eps])
+	  linear_extrude(height=tile_thickness + 2 * bool_eps) difference() {
+	  difference() {
+	    translate([hanger_x_offset, tile_hanger_y_offset, 0])
+	      square([tile_hanger_width, tile_hanger_height]);
+	    translate([threaded_hole_center_x, threaded_hole_center_y, 0])
+	      circle(tile_hanger_hole_outer_diameter);
+	  }
+	}
 
         // Threaded hole
         translate([threaded_hole_center_x, threaded_hole_center_y, 0])

--- a/tile_stack.scad
+++ b/tile_stack.scad
@@ -23,33 +23,29 @@ include <BOSL2/threading.scad>
 use <tile.scad>
 use <grid_tile.scad>
 
+include <parsers.scad>
+
 /* [Stack] */
 
-// "hex" or "grid". Hex is the primary path here.
-tile_kind = "hex";
+// "hex" or "grid"
+tile_kind = "hex"; // [hex, grid]
 
 // "pla", "petg", or "all" for preview
-part = "all";
+part = "all"; // [all, pla, petg]
 
-// Number of actual GOEWS tiles in the stack
 stack_count = 3;
 
-// PETG separator thickness.
-// Try 0.2 for one layer, 0.4 for two layers.
-spacer_h = 0.2;
+spacer_h = 0.6;
 
-// Shrink the separator slightly so it does not poke past the plate edge/chamfer.
+// Shrinks separator slightly so PETG does not peek past the plate edge.
 spacer_xy_delta = -0.20;
 
-// "hex_cells" is fast and recommended for hex GOEWS plates.
-// "projection_close" is slower, but useful if you use GOEWS fill_top/fill_bottom/etc.
-separator_mode = "hex_cells";
+// "hex_cells" is the recommended fast path for hex GOEWS plates.
+// "projection_close" is slower, but handles fill_top/fill_bottom/etc better.
+separator_mode = "hex_cells"; // [hex_cells, projection_close]
 
-// Used only by separator_mode="projection_close".
-// Should be bigger than the largest hole radius you want closed.
 separator_close_radius = 9;
 
-// Tiny visual/alignment nudge, in case your local GOEWS checkout differs.
 separator_nudge_x = 0;
 separator_nudge_y = 0;
 
@@ -58,56 +54,37 @@ separator_nudge_y = 0;
 enable_pull_tabs = true;
 
 // "right", "left", "front", or "back"
-// Right is the safest default for normal hex plates because the default stagger
-// usually gives you a good mid-row attachment on that side.
-tab_side = "right";
+tab_side = "right"; // [right, left, front, back]
 
-// How far the PETG tab sticks out beyond the plate footprint.
 tab_len = 22;
-
-// Width of the PETG tab.
-tab_width = 18;
-
-// How much the PETG tab overlaps into the separator sheet.
+tab_width = 14;
 tab_overlap = 4;
-
-// Rounded tab corners.
-tab_radius = 3;
+tab_radius = 2.5;
 
 /* [PLA Tab Supports] */
 
-// Add modeled PLA support islands under the exposed PETG pull tabs.
-// These are actual PLA geometry, not slicer-generated supports.
 enable_tab_supports = true;
 
-// Keep support island separated from the tile by this much.
+// Gap between main tile body and PLA support island.
 tab_support_tile_gap = 1.5;
 
-// Leave this much of the outer PETG tab unsupported/free for easier grabbing.
-tab_tip_free = 5;
+// 0 means support reaches all the way to the PETG tab end.
+// Increase only if you intentionally want unsupported PETG at the very tip.
+tab_tip_free = 0;
 
-// Width of PLA support under tab.
-// Slightly narrower than tab_width makes it easier to break away.
 tab_support_width = 14;
-
-// Slightly round the support island corners.
 tab_support_radius = 2;
 
-// Height gap below PETG separator.
-// 0 gives the best tab print reliability.
-// Try 0.05 only if PETG bonds too hard to the PLA support.
+// 0 gives best PETG tab print reliability.
 tab_support_z_gap = 0;
 
 /* [GOEWS Tile Parameters] */
 
-variant = 1; // 0 original, 1 thicker cleats
+variant = 1;
 
 columns = 4;
 rows = 4;
 
-// Hex edge fill params.
-// The fast hex_cells separator does not model these fill pieces.
-// Use separator_mode="projection_close" when these are enabled.
 fill_top = false;
 fill_bottom = false;
 fill_left = false;
@@ -118,7 +95,8 @@ exact_width = false;
 
 // GOEWS skiplist uses 1-based [row, column] entries.
 // Example: [[1, 2], [3, 4]]
-skiplist = [];
+skip_list = "";
+skiplist = parse_vector_list(skip_list);
 
 mounting_hole_shank_diameter = 4;
 mounting_hole_head_diameter = 8;
@@ -132,7 +110,6 @@ $fs = 0.5;
 
 stack_pitch = tile_thickness + spacer_h;
 
-// Match tile.scad's stagger logic.
 function hex_stagger_0() = reverse_stagger ? 1 : 0;
 function hex_stagger_1() = reverse_stagger ? 0 : 1;
 
@@ -147,6 +124,12 @@ function hex_row_min_x(row) =
 
 function hex_row_max_x(row) =
   hex_row_offset_x(row) + columns * tile_width;
+
+function hex_row_center_x(row) =
+  (hex_row_min_x(row) + hex_row_max_x(row)) / 2;
+
+function hex_row_center_y(row) =
+  row * tile_y_offset + tile_height / 2;
 
 hex_min_x = min([for (row = [0 : rows - 1]) hex_row_min_x(row)]);
 hex_max_x = max([for (row = [0 : rows - 1]) hex_row_max_x(row)]);
@@ -166,6 +149,47 @@ footprint_max_y = tile_kind == "grid" ? grid_max_y : hex_max_y;
 footprint_center_x = (footprint_min_x + footprint_max_x) / 2;
 footprint_center_y = (footprint_min_y + footprint_max_y) / 2;
 
+// Pick a real exposed hex row near the middle, rather than the overall bbox.
+// This fixes tabs floating beside an indented hex edge.
+hex_center_row = floor((rows - 1) / 2);
+
+function hex_nearest_right_row(r=hex_center_row) =
+  rows <= 1 ? 0 :
+  hex_row_max_x(r) == hex_max_x ? r :
+  r > 0 && hex_row_max_x(r - 1) == hex_max_x ? r - 1 :
+  r + 1 < rows && hex_row_max_x(r + 1) == hex_max_x ? r + 1 :
+  r;
+
+function hex_nearest_left_row(r=hex_center_row) =
+  rows <= 1 ? 0 :
+  hex_row_min_x(r) == hex_min_x ? r :
+  r > 0 && hex_row_min_x(r - 1) == hex_min_x ? r - 1 :
+  r + 1 < rows && hex_row_min_x(r + 1) == hex_min_x ? r + 1 :
+  r;
+
+hex_right_tab_row = hex_nearest_right_row();
+hex_left_tab_row = hex_nearest_left_row();
+hex_front_tab_row = 0;
+hex_back_tab_row = rows - 1;
+
+function tab_anchor_x() =
+  tile_kind == "hex" && tab_side == "right" ? hex_row_max_x(hex_right_tab_row) :
+  tile_kind == "hex" && tab_side == "left"  ? hex_row_min_x(hex_left_tab_row) :
+  tile_kind == "hex" && tab_side == "back"  ? hex_row_center_x(hex_back_tab_row) :
+  tile_kind == "hex" && tab_side == "front" ? hex_row_center_x(hex_front_tab_row) :
+  tab_side == "right" ? footprint_max_x :
+  tab_side == "left"  ? footprint_min_x :
+  footprint_center_x;
+
+function tab_anchor_y() =
+  tile_kind == "hex" && tab_side == "right" ? hex_row_center_y(hex_right_tab_row) :
+  tile_kind == "hex" && tab_side == "left"  ? hex_row_center_y(hex_left_tab_row) :
+  tile_kind == "hex" && tab_side == "back"  ? hex_max_y :
+  tile_kind == "hex" && tab_side == "front" ? hex_min_y :
+  tab_side == "back"  ? footprint_max_y :
+  tab_side == "front" ? footprint_min_y :
+  footprint_center_y;
+
 module rounded_rect_2d(size=[10, 5], r=2) {
   rr = min(r, min(size[0], size[1]) / 2 - 0.01);
 
@@ -176,8 +200,6 @@ module rounded_rect_2d(size=[10, 5], r=2) {
     ], center=true);
 }
 
-// Solid 2D version of GOEWS' pointy hex tile outline.
-// This deliberately omits hanger holes, screw holes, rear cuts, etc.
 module solid_hex_cell_2d() {
   polygon(points=[
     [tile_width / 2, 0],
@@ -244,9 +266,6 @@ module hex_cells_separator_2d() {
       }
 }
 
-// Slower fallback that preserves the projected outside outline much better than hull().
-// This can handle fill_top/fill_bottom/fill_left/fill_right more faithfully,
-// but it is much slower because it projects the real tile.
 module projection_closed_separator_2d() {
   translate([separator_nudge_x, separator_nudge_y])
     offset(delta=spacer_xy_delta)
@@ -273,70 +292,47 @@ module separator_footprint_2d() {
 }
 
 module tab_2d() {
+  ax = tab_anchor_x();
+  ay = tab_anchor_y();
+
   if (tab_side == "right") {
-    translate([
-      footprint_max_x + (tab_len - tab_overlap) / 2,
-      footprint_center_y
-    ])
+    translate([ax + (tab_len - tab_overlap) / 2, ay])
       rounded_rect_2d([tab_len + tab_overlap, tab_width], tab_radius);
 
   } else if (tab_side == "left") {
-    translate([
-      footprint_min_x - (tab_len - tab_overlap) / 2,
-      footprint_center_y
-    ])
+    translate([ax - (tab_len - tab_overlap) / 2, ay])
       rounded_rect_2d([tab_len + tab_overlap, tab_width], tab_radius);
 
   } else if (tab_side == "back") {
-    translate([
-      footprint_center_x,
-      footprint_max_y + (tab_len - tab_overlap) / 2
-    ])
+    translate([ax, ay + (tab_len - tab_overlap) / 2])
       rounded_rect_2d([tab_width, tab_len + tab_overlap], tab_radius);
 
   } else {
-    // "front"
-    translate([
-      footprint_center_x,
-      footprint_min_y - (tab_len - tab_overlap) / 2
-    ])
+    translate([ax, ay - (tab_len - tab_overlap) / 2])
       rounded_rect_2d([tab_width, tab_len + tab_overlap], tab_radius);
   }
 }
 
-// Support is intentionally separated from the tile footprint.
-// It starts outside the plate edge plus tab_support_tile_gap,
-// and stops before the tab tip by tab_tip_free.
 module tab_support_2d() {
-  support_len = max(0.01, tab_len - tab_tip_free - tab_support_tile_gap);
+  ax = tab_anchor_x();
+  ay = tab_anchor_y();
+
+  support_len = max(0.01, tab_len - tab_support_tile_gap - tab_tip_free);
 
   if (tab_side == "right") {
-    translate([
-      footprint_max_x + tab_support_tile_gap + support_len / 2,
-      footprint_center_y
-    ])
+    translate([ax + tab_support_tile_gap + support_len / 2, ay])
       rounded_rect_2d([support_len, tab_support_width], tab_support_radius);
 
   } else if (tab_side == "left") {
-    translate([
-      footprint_min_x - tab_support_tile_gap - support_len / 2,
-      footprint_center_y
-    ])
+    translate([ax - tab_support_tile_gap - support_len / 2, ay])
       rounded_rect_2d([support_len, tab_support_width], tab_support_radius);
 
   } else if (tab_side == "back") {
-    translate([
-      footprint_center_x,
-      footprint_max_y + tab_support_tile_gap + support_len / 2
-    ])
+    translate([ax, ay + tab_support_tile_gap + support_len / 2])
       rounded_rect_2d([tab_support_width, support_len], tab_support_radius);
 
   } else {
-    // "front"
-    translate([
-      footprint_center_x,
-      footprint_min_y - tab_support_tile_gap - support_len / 2
-    ])
+    translate([ax, ay - tab_support_tile_gap - support_len / 2])
       rounded_rect_2d([tab_support_width, support_len], tab_support_radius);
   }
 }

--- a/tile_stack.scad
+++ b/tile_stack.scad
@@ -103,6 +103,34 @@ mounting_hole_head_diameter = 8;
 mounting_hole_inset_depth = 1;
 mounting_hole_countersink_depth = 2;
 
+/* [Separator Hole Relief] */
+
+// Clearance around the threaded GOEWS bolt hole in the PETG separator.
+// Increase this if the threaded hole still shows separator droop.
+separator_threaded_hole_clearance = 0.8;
+
+// Maximum unsupported distance the next tile's first layer has to bridge
+// around the mounting shank hole. Larger values open more of the screw inset;
+// smaller values give the next tile more support.
+separator_mounting_hole_start_overhang = 0.8;
+
+// Keep this much PETG lip around the screw-head inset edge.
+// This prevents the separator from trying to bridge the whole inset.
+separator_mounting_inset_edge_lip = 0.8;
+
+// Keep this much PETG lip around the central hanger/window cutout.
+// Larger values support the next tile more; smaller values open more of the window.
+separator_window_edge_lip = 2.5;
+
+// Rounded corner radius for the hanger/window relief cut.
+separator_window_corner_radius = 2.5;
+
+// Leave PETG under the circular pad around the GOEWS bolt hole.
+// Larger values remove more PETG around that circular pad; smaller values
+// leave more PETG separator material. This should stay smaller than the
+// circular pad radius.
+separator_window_threaded_pad_clearance = -0.5;
+
 /* [Hidden] */
 
 $fa = 0.5;
@@ -189,6 +217,36 @@ function tab_anchor_y() =
   tab_side == "back"  ? footprint_max_y :
   tab_side == "front" ? footprint_min_y :
   footprint_center_y;
+
+function separator_threaded_hole_cut_radius() =
+  (thread_diameter + thread_tolerance) / 2 + separator_threaded_hole_clearance;
+
+function separator_mounting_hole_cut_radius() =
+  max(
+    mounting_hole_shank_diameter / 2,
+    min(
+      mounting_hole_shank_diameter / 2 + separator_mounting_hole_start_overhang,
+      mounting_hole_head_diameter / 2 - separator_mounting_inset_edge_lip
+    )
+  );
+
+function separator_window_cut_width() =
+  max(0.01, tile_hanger_width - 2 * separator_window_edge_lip);
+
+function separator_window_cut_height() =
+  max(0.01, tile_hanger_height - 2 * separator_window_edge_lip);
+
+function separator_window_cut_radius() =
+  min(
+    separator_window_corner_radius,
+    min(separator_window_cut_width(), separator_window_cut_height()) / 2 - 0.01
+  );
+
+function separator_window_threaded_pad_keep_radius() =
+  max(
+    separator_threaded_hole_cut_radius(),
+    tile_hanger_hole_outer_diameter - separator_window_threaded_pad_clearance
+  );
 
 module rounded_rect_2d(size=[10, 5], r=2) {
   rr = min(r, min(size[0], size[1]) / 2 - 0.01);
@@ -291,6 +349,69 @@ module separator_footprint_2d() {
   }
 }
 
+module separator_window_relief_2d() {
+  hanger_x_offset = (tile_width - tile_hanger_width) / 2;
+
+  difference() {
+    translate([
+      hanger_x_offset + tile_hanger_width / 2,
+      tile_triangle_height + tile_hanger_height / 2
+    ])
+      rounded_rect_2d(
+        [separator_window_cut_width(), separator_window_cut_height()],
+        separator_window_cut_radius()
+      );
+
+    // Keep separator material under the circular boss/pad around the GOEWS
+    // bolt hole. The actual threaded hole is still cut separately by
+    // hex_separator_hole_relief_2d().
+    translate([tile_width / 2, tile_height - tile_threaded_hole_y_offset])
+      circle(r=separator_window_threaded_pad_keep_radius());
+  }
+}
+
+module hex_separator_hole_relief_2d() {
+  translate([separator_nudge_x, separator_nudge_y])
+    union() {
+      for (row = [0 : rows - 1]) {
+        offset_x = hex_row_offset_x(row);
+        start_column = hex_row_start_column(row);
+        pos_y = row * tile_y_offset;
+
+        for (column = [start_column : columns - 1]) {
+          pos_x = offset_x + column * tile_width;
+
+          if (!in_list([row + 1, column + 1], skiplist)) {
+            translate([pos_x, pos_y]) {
+              // Open most of the central hanger/window area, leaving a small
+              // lip so the next tile's first layers have somewhere to start.
+              // The circular GOEWS-bolt pad is protected by
+              // separator_window_relief_2d(), then the actual threaded hole is
+              // cut separately below.
+              separator_window_relief_2d();
+
+              // Do not bridge the threaded GOEWS bolt hole.
+              translate([tile_width / 2, tile_height - tile_threaded_hole_y_offset])
+                circle(r=separator_threaded_hole_cut_radius());
+
+              // Open most of the mounting screw inset, while leaving a small
+              // PETG ledge to support the next tile's first layer around the
+              // shank hole.
+              translate([tile_width / 2, tile_mounting_hole_y_offset])
+                circle(r=separator_mounting_hole_cut_radius());
+            }
+          }
+        }
+      }
+    }
+}
+
+module separator_hole_relief_2d() {
+  if (tile_kind == "hex") {
+    hex_separator_hole_relief_2d();
+  }
+}
+
 module tab_2d() {
   ax = tab_anchor_x();
   ay = tab_anchor_y();
@@ -339,11 +460,15 @@ module tab_support_2d() {
 
 module separator_sheet() {
   linear_extrude(height=spacer_h)
-    union() {
-      separator_footprint_2d();
+    difference() {
+      union() {
+        separator_footprint_2d();
 
-      if (enable_pull_tabs)
-        tab_2d();
+        if (enable_pull_tabs)
+          tab_2d();
+      }
+
+      separator_hole_relief_2d();
     }
 }
 

--- a/tile_stack.scad
+++ b/tile_stack.scad
@@ -1,9 +1,9 @@
-// stacked_goews_tiles.scad
+// tile_stack.scad
 //
 // Export twice:
 //
-//   openscad -o goews-stack-pla.stl  -D 'part="pla"'  stacked_goews_tiles.scad
-//   openscad -o goews-stack-petg.stl -D 'part="petg"' stacked_goews_tiles.scad
+//   openscad -o goews-stack-pla.stl  -D 'part="pla"'  tile_stack.scad
+//   openscad -o goews-stack-petg.stl -D 'part="petg"' tile_stack.scad
 //
 // Then import both STLs into Orca as one multi-part object.
 // Assign PLA to goews-stack-pla.stl and PETG to goews-stack-petg.stl.

--- a/tile_stack.scad
+++ b/tile_stack.scad
@@ -107,7 +107,7 @@ mounting_hole_countersink_depth = 2;
 
 // Clearance around the threaded GOEWS bolt hole in the PETG separator.
 // Increase this if the threaded hole still shows separator droop.
-separator_threaded_hole_clearance = 0.8;
+separator_threaded_hole_clearance = -0.8;
 
 // Maximum unsupported distance the next tile's first layer has to bridge
 // around the mounting shank hole. Larger values open more of the screw inset;


### PR DESCRIPTION

<img width="1703" height="667" alt="screenshot" src="https://github.com/user-attachments/assets/f2ed5cab-0005-4938-a67f-f2b6c6595e70" />

This is an addon for users with multimaterial printers so they can create stacks of tiles to print at once in batch form. The intent is to let users print multiple tiles in a stack in PLA with PETG separators (or the other way around I guess?) for later separation. This way we can just queue up a 16-hour job and let it run without checkin in for a while.

- Added `tile_stack.scad` that calls the existing tiles and creates tile stacks. The user can configure number of stacks. Each tile is separated from the previous with a separator layer (and a supported pull tab for ease-of-use).
- Added `server/parts/tile_stack.py` so that this stack option appears in the generator UI
- imported `tile_stack` in `server.py`
- tweaked `PartTreeSelector.svelte` to include the new `tile_stack` option
- tweaked `App.svelte` and `api.js` to allow for .zip downloads (tile_stack emits two STLs; one for the tile body and one for the separators; this is currently implemented as a zip file containing both STLs)
- tweaked `App.svelte` and `STLViewer.svelte` to allow multicolor preview (fully backwards compatible with other models; tile-stack currently previews with the tiles in blue and separators in yellow).
- fixed minor bug that showed cosmetic micro-layer over top of the hex tile cleat hole and mounting hole
- added emacs intermediate files to `.gitignore`
- added README section for tile stacks